### PR TITLE
Fix AppleScript result handling

### DIFF
--- a/next-toggl-track.xcodeproj/project.pbxproj
+++ b/next-toggl-track.xcodeproj/project.pbxproj
@@ -453,8 +453,9 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				LD_RUNPATH_SEARCH_PATHS = (
+                               INFOPLIST_KEY_NSHumanReadableCopyright = "";
+                               INFOPLIST_KEY_NSAppleEventsUsageDescription = "This app needs access to control other apps for retrieving browser URLs.";
+                               LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
@@ -480,8 +481,9 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				LD_RUNPATH_SEARCH_PATHS = (
+                               INFOPLIST_KEY_NSHumanReadableCopyright = "";
+                               INFOPLIST_KEY_NSAppleEventsUsageDescription = "This app needs access to control other apps for retrieving browser URLs.";
+                               LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);

--- a/next-toggl-track/FocusMonitor.swift
+++ b/next-toggl-track/FocusMonitor.swift
@@ -108,20 +108,21 @@ class FocusMonitor {
         
         
         var error: NSDictionary?
-        if let script = NSAppleScript(source: scriptSource) {
-            let output = script.executeAndReturnError(&error)
-            
-            print("iei output: \(output)")
-            print("iei output.stringValue: \(output.stringValue)")
-            print("iei error: \(error)")
-            
-            guard let result = output.stringValue else {
-                return nil
-                
-            }
-            return result
+        guard let script = NSAppleScript(source: scriptSource) else {
+            return nil
         }
-        
-        return nil
+
+        let output = script.executeAndReturnError(&error)
+
+        if let error = error {
+            logger.error("AppleScript error: \(error)")
+            return nil
+        }
+
+        guard let result = output.stringValue else {
+            return nil
+        }
+
+        return result
     }
 }


### PR DESCRIPTION
## Summary
- add NSAppleEventsUsageDescription so macOS permits AppleScript
- handle errors from `executeAndReturnError` in `FocusMonitor`

## Testing
- `swift -version`

------
https://chatgpt.com/codex/tasks/task_e_685cffe904fc83288fbacdb1e5523d47