### PR TITLE
Fix scheduled keyboard log flush

### DIFF
--- a/next-toggl-track/KeyInputParser.swift
+++ b/next-toggl-track/KeyInputParser.swift
@@ -24,15 +24,17 @@ class KeyInputParser: ObservableObject {
     init() {
         // Start timer to flush logs to disk every 10 seconds
         timer = Timer.scheduledTimer(withTimeInterval: 10.0, repeats: true) { [weak self] _ in
-            let text = (self?.logQueue.joined(separator: "\n") ?? "") + "\n"
-            //TODO: うまく反映されない。以下のDispatchQueue.main.asyncでも同じ（この場合は、ファイルの内容が毎回必ず読み込まれているかも？）
-            self?.appendLog_parsed(eventType: "keyboard(scheduled batch)", content: text)
-        
-//            DispatchQueue.main.async {
-//                self?.appendLog_parsed(eventType: "keyboard(scheduled batch)", content: text)
-//            }
-//            
-            self?.flushLog_parsed()
+            guard let self else { return }
+
+            // バッファに溜まったキーボード入力を1行にまとめて保存する
+            let text = self.log
+            self.log = ""
+
+            if !text.isEmpty {
+                self.appendLog_parsed(eventType: "keyboard(scheduled batch)", content: text)
+            }
+
+            self.flushLog_parsed()
         }
     }
     


### PR DESCRIPTION
## Summary
- capture typed text via `KeyInputParser` and write it in scheduled batches
- avoid appending empty log entries

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6886055c3ea48328a3f8ef8c49b85565