### PR TITLE
Fix scheduled keyboard log batching

### DIFF
--- a/next-toggl-track/KeyInputParser.swift
+++ b/next-toggl-track/KeyInputParser.swift
@@ -24,15 +24,16 @@ class KeyInputParser: ObservableObject {
     init() {
         // Start timer to flush logs to disk every 10 seconds
         timer = Timer.scheduledTimer(withTimeInterval: 10.0, repeats: true) { [weak self] _ in
-            let text = (self?.logQueue.joined(separator: "\n") ?? "") + "\n"
-            //TODO: うまく反映されない。以下のDispatchQueue.main.asyncでも同じ（この場合は、ファイルの内容が毎回必ず読み込まれているかも？）
-            self?.appendLog_parsed(eventType: "keyboard(scheduled batch)", content: text)
-        
-//            DispatchQueue.main.async {
-//                self?.appendLog_parsed(eventType: "keyboard(scheduled batch)", content: text)
-//            }
-//            
-            self?.flushLog_parsed()
+            guard let self = self else { return }
+
+            // 直近 10 秒間の入力内容をまとめて書き出す
+            let typed = self.log
+            self.log = ""
+            if !typed.isEmpty {
+                self.appendLog_parsed(eventType: "keyboard(scheduled batch)", content: typed)
+            }
+
+            self.flushLog_parsed()
         }
     }
     


### PR DESCRIPTION
## Summary
- flush keyboard input every 10 seconds

## Testing
- `swiftc next-toggl-track/KeyInputParser.swift -o /tmp/testbinary` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6886055c3ea48328a3f8ef8c49b85565